### PR TITLE
Functionality to create custom commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "onCommand:randomeverything.hexColor",
         "onCommand:randomeverything.iPv4Address",
         "onCommand:randomeverything.iPV6Address",
-        "onCommand:randomeverything.guid"
+        "onCommand:randomeverything.guid",
+        "onCommand:randomeverything.custom"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -58,6 +59,11 @@
                     "type": "boolean",
                     "default": "true",
                     "description": "Enable/disable this extension."
+                },
+                "randomeverything.custom": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Define custom strings or lists to generate random values from."
                 }
             }
         },
@@ -146,6 +152,11 @@
                 "command": "randomeverything.guid",
                 "title": "Random: GUID",
                 "description": "Generates a random GUID"
+            },
+            {
+                "command": "randomeverything.custom",
+                "title": "Random: Custom",
+                "description": "Generates random strings from items or characters specified in settings"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "randomeverything",
     "displayName": "Random Everything",
     "description": "Generate random ints, floats, strings, words, etc.",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "helixquar",
     "engines": {
         "vscode": "^1.5.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,16 +50,15 @@ function insertRandomCustom(): void {
     var settings = new Settings();
 
     // create a quickpick of all custom random strings/items
-    const prev = previous ? [`${previous} (prev)`] : [];
-    const keys = prev.concat(Object.keys(settings.Custom));
+    const prevString = `${previous} (prev)`
+    const keys = Object.keys(settings.Custom);
+    const items = previous ? [prevString].concat(keys) : keys
 
-    var count = 0;
-    vscode.window.showQuickPick(keys, { placeHolder: previous }).then((key) => {
+    vscode.window.showQuickPick(items, { placeHolder: previous }).then((key) => {
         if (key == null) return;
 
-        if (count == 0 && previous) key = previous;
-
-        count++
+        if (key === prevString) key = previous;
+        
         previous = key;
         processSelection(randomCustom, [settings.Custom[key]]);
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,13 +16,13 @@ import Workspace = vscode.workspace;
 
 export function activate(context: vscode.ExtensionContext) {
 
-    var settings = new Settings();
+  var settings = new Settings();
 
     if(!settings.Enabled)
     {
         console.log("The extension \"randomeverything\" is disabled.");
-        return;
-    }
+    return;
+  }
 
     context.subscriptions.push(vscode.commands.registerCommand('randomeverything.int', insertRandomInt));
     context.subscriptions.push(vscode.commands.registerCommand('randomeverything.float', insertRandomFloat));
@@ -41,11 +41,47 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('randomeverything.iPv4Address', insertRandomIPv4Address));
     context.subscriptions.push(vscode.commands.registerCommand('randomeverything.iPV6Address', insertRandomIPV6Address));
     context.subscriptions.push(vscode.commands.registerCommand('randomeverything.guid', insertRandomGUID));
+    context.subscriptions.push(vscode.commands.registerCommand("randomeverything.custom", insertRandomCustom));
+}
 
+// tracks the previously selected custom input
+var previous: string = "";
+function insertRandomCustom(): void {
+    var settings = new Settings();
+
+    // create a quickpick of all custom random strings/items
+    const prev = previous ? [`${previous} (prev)`] : [];
+    const keys = prev.concat(Object.keys(settings.Custom));
+
+    var count = 0;
+    vscode.window.showQuickPick(keys, { placeHolder: previous }).then((key) => {
+        if (key == null) return;
+
+        if (count == 0 && previous) key = previous;
+
+        count++
+        previous = key;
+        processSelection(randomCustom, [settings.Custom[key]]);
+    });
+}
+
+// generates a string from a string of provided chars
+// or generates a string from an array of strings
+function randomCustom(items: string | string[]) {
+    var chance = require("chance").Chance();
+    if (typeof(items) === "string") {
+        return chance.string({ pool: items });
+    }
+
+    if (items instanceof Array) {
+        return chance.pickone(items);
+    }
+
+    return "";
 }
 
 function insertRandomInt(): void {
-
+    
     var max:number;
     var min:number;
 
@@ -194,8 +230,8 @@ function randomWord(): string{
     var chance = require('chance').Chance();
     let extensionPath = vscode.extensions.getExtension("helixquar.randomeverything").extensionPath;
     var strings = fs.readFileSync(extensionPath + "/assets/words.short.txt")
-                    .toString()
-                    .split("\r\n");
+    .toString()
+    .split("\r\n");
     var randomVar:string = chance.pickone(strings);
 
     return randomVar;
@@ -205,8 +241,8 @@ function randomText(): string{
     var chance = require('chance').Chance();
     let extensionPath = vscode.extensions.getExtension("helixquar.randomeverything").extensionPath;
     var strings = fs.readFileSync(extensionPath + "/assets/words.short.txt")
-                    .toString()
-                    .split("\r\n");
+    .toString()
+    .split("\r\n");
     var randomVar: string[] = chance.pickset(strings, 24);
 
     return randomVar.join(' ');
@@ -275,7 +311,7 @@ function randomIP(option?:string): string{
             break;
     }
 
-    return randomVar;
+  return randomVar;
 }
 
 function randomGUID(): string{

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,14 +16,20 @@ abstract class BaseSettings {
 
 export class Settings extends BaseSettings {
     private _enabled: boolean;
+    private _custom: { [key: string]: string | string[] }
 
     constructor() {
         super();
 
         this._enabled = this.readSetting<boolean>("randomeverything.enabled", true);
+        this._custom = this.readSetting<{ [key: string]: string | string[] }>("randomeverything.custom", {})
     }
 
     public get Enabled(): boolean {
         return this._enabled;
+    }
+
+    public get Custom(): { [key: string]: string | string[] } {
+        return this._custom;
     }
 }


### PR DESCRIPTION
This pull request adds the ability to create custom commands through the workspace settings.

Adds a setting called `randomeverything.custom` which is an object where the keys represent the name of the custom command, the the value (either a string or a list of strings) is the data used in generation. If the value is a string, then the command will generate a string sampling from those characters. If it is a list of strings, then it will pick one from the list. It will also track the most recently used input and place it at the top for easy selection.

Here's are some pics:

### Example Config
![image](https://user-images.githubusercontent.com/60640764/223227982-4fbf480f-c70c-4513-87af-d755752573fc.png)

### Custom command
![image](https://user-images.githubusercontent.com/60640764/223228042-735100d9-9993-4404-94be-080f9d2a1ac2.png)

### Custom commands from config file
![image](https://user-images.githubusercontent.com/60640764/223228706-35b98d00-a092-4699-a19a-502d827719a8.png)

### Output from selection
![image](https://user-images.githubusercontent.com/60640764/223228291-aa308c7c-0233-46e1-9bbf-36762da74f00.png)

### Custom command with previous selection
![image](https://user-images.githubusercontent.com/60640764/223228264-f71f127f-7e86-4a8b-85f9-9b743d8c9f9b.png)
